### PR TITLE
Fix npm publish authentication in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,15 @@ jobs:
       id-token: write
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
+
 
     - name: Install dependencies
       run: npm ci
@@ -29,5 +31,3 @@ jobs:
 
     - name: Publish to npm
       run: npm publish --provenance
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,3 +31,5 @@ jobs:
 
     - name: Publish to npm
       run: npm publish --provenance
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,3 +29,5 @@ jobs:
 
     - name: Publish to npm
       run: npm publish --provenance
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4
@@ -25,6 +28,4 @@ jobs:
       run: npm run build
 
     - name: Publish to npm
-      run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
         package-manager-cache: false
 
-
     - name: Install dependencies
       run: npm ci
 
@@ -30,6 +29,6 @@ jobs:
       run: npm run build
 
     - name: Publish to npm
-      run: npm publish --provenance
+      run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsx-dom-runtime",
-  "version": "0.80.1",
+  "version": "0.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsx-dom-runtime",
-      "version": "0.80.1",
+      "version": "0.81.0",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-dom-runtime",
-  "version": "0.80.1",
+  "version": "0.81.0",
   "description": "A tiny 500-byte library for JSX syntax templates targeting the DOM. Supports HTML, SVG, and MathML tags",
   "type": "module",
   "main": "jsx-runtime/index.cjs",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/shoonia/jsx-dom-runtime.git"
+    "url": "git+https://github.com/shoonia/jsx-dom-runtime.git"
   },
   "bugs": {
     "url": "https://github.com/shoonia/jsx-dom-runtime/issues"


### PR DESCRIPTION
The `publish` GitHub Actions job was failing at `npm publish` with `E404` while attempting to release `jsx-dom-runtime@0.81.0`. The workflow was signing provenance correctly, but the publish step was no longer explicitly using the npm publish token.

- **Publish auth**
  - Restore `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN` on the `npm publish` step.
  - Ensure the publish command authenticates against npm with the expected token instead of relying on implicit token wiring.

- **Provenance**
  - Keep `npm publish --provenance` so releases continue to publish with npm provenance metadata.
  - Retain the job permissions required for provenance signing.

- **Workflow scope**
  - Limit the change to `/home/runner/work/jsx-dom-runtime/jsx-dom-runtime/.github/workflows/publish.yml`.
  - Leave install/build behavior unchanged.

```yaml
- name: Publish to npm
  run: npm publish --provenance
  env:
    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```