### PR TITLE
Add MathML support in namespace transformations and utility imports

### DIFF
--- a/tests/ns-transform.spec.ts
+++ b/tests/ns-transform.spec.ts
@@ -14,7 +14,7 @@ describe('ns-transform', () => {
       <svg>
         {link && <a href={link}>Welcome</a>}
       </svg>
-    `).toBeTransform(svgImport`_jsx("svg",{_:_svgNs},link&&/*#__PURE__*/_jsx("a",{href:link,_:_svgNs},"Welcome");`);
+    `).toBeTransform(svgImport`_jsx("svg",{_:_svgNs},link&&/*#__PURE__*/_jsx("a",{href:link,_:_svgNs},"Welcome"));`);
   });
 
   it('should transform <a> as MathML in the conditional operator', async () => {

--- a/tests/ns-transform.spec.ts
+++ b/tests/ns-transform.spec.ts
@@ -1,12 +1,12 @@
-describe('ns-transform', () => {
-  const start = 'import{svgNs as _svgNs,jsx as _jsx}from"jsx-dom-runtime";/*#__PURE__*/';
+import { mathmlImport, svgImport } from './utils/t';
 
+describe('ns-transform', () => {
   it('should transform <a> as SVG in the conditional operator', async () => {
     await expect(`
       <svg>
         {link ? <a href={link}>Welcome</a> : null}
       </svg>
-    `).toBeTransform(start + '_jsx("svg",{_:_svgNs},link?/*#__PURE__*/_jsx("a",{href:link,_:_svgNs},"Welcome"):null);');
+    `).toBeTransform(svgImport`_jsx("svg",{_:_svgNs},link?/*#__PURE__*/_jsx("a",{href:link,_:_svgNs},"Welcome"):null);`);
   });
 
   it('should transform <a> as SVG in the AND operator', async () => {
@@ -14,7 +14,23 @@ describe('ns-transform', () => {
       <svg>
         {link && <a href={link}>Welcome</a>}
       </svg>
-    `).toBeTransform(start + '_jsx("svg",{_:_svgNs},link&&/*#__PURE__*/_jsx("a",{href:link,_:_svgNs},"Welcome"));');
+    `).toBeTransform(svgImport`_jsx("svg",{_:_svgNs},link&&/*#__PURE__*/_jsx("a",{href:link,_:_svgNs},"Welcome");`);
+  });
+
+  it('should transform <a> as MathML in the conditional operator', async () => {
+    await expect(`
+      <math>
+        {link ? <a href={link}>Welcome</a> : null}
+      </math>
+    `).toBeTransform(mathmlImport`_jsx("math",{_:_mathmlNs},link?/*#__PURE__*/_jsx("a",{href:link,_:_mathmlNs},"Welcome"):null);`);
+  });
+
+  it('should transform <a> as MathML in nested MathML parent elements', async () => {
+    await expect(`
+      <math>
+        <mrow>{link && <a href={link}>Welcome</a>}</mrow>
+      </math>
+    `).toBeTransform(mathmlImport`_jsx("math",{_:_mathmlNs},/*#__PURE__*/_jsx("mrow",{_:_mathmlNs},link&&/*#__PURE__*/_jsx("a",{href:link,_:_mathmlNs},"Welcome")));`);
   });
 
   it('should NO transform <a> as SVG in the conditional operator when it out of <svg> tag', async () => {
@@ -29,7 +45,13 @@ describe('ns-transform', () => {
 
   it('should add namespace to any tags inside SVG parent element', async () => {
     await expect('<svg><unknown some="tag" /><div>hello</div></svg>').toBeTransform(
-      start + '_jsx("svg",{_:_svgNs},[/*#__PURE__*/_jsx("unknown",{some:"tag",_:_svgNs}),/*#__PURE__*/_jsx("div",{_:_svgNs},"hello")]);',
+      svgImport`_jsx("svg",{_:_svgNs},[/*#__PURE__*/_jsx("unknown",{some:"tag",_:_svgNs}),/*#__PURE__*/_jsx("div",{_:_svgNs},"hello")]);`,
+    );
+  });
+
+  it('should add namespace to any tags inside MathML parent element', async () => {
+    await expect('<math><unknown some="tag" /><a href={link}>hello</a></math>').toBeTransform(
+      mathmlImport`_jsx("math",{_:_mathmlNs},[/*#__PURE__*/_jsx("unknown",{some:"tag",_:_mathmlNs}),/*#__PURE__*/_jsx("a",{href:link,_:_mathmlNs},"hello")]);`,
     );
   });
 });

--- a/tests/ns.spec.tsx
+++ b/tests/ns.spec.tsx
@@ -32,6 +32,7 @@ describe('ns', () => {
     expect(<a />).toHaveProperty(prop, xhtmlNs);
     expect(<a _={xhtmlNs} />).toHaveProperty(prop, xhtmlNs);
     expect(<a _={svgNs} />).toHaveProperty(prop, svgNs);
+    expect(<a _={mathmlNs} />).toHaveProperty(prop, mathmlNs);
   });
 
   it('should have SVG `namespaceURI` for `script` tag', () => {
@@ -59,9 +60,17 @@ describe('ns', () => {
   it('should detect namespace from parent tag for `a` tag', () => {
     const div = <div><a /></div>;
     const svg = <svg><a /></svg>;
+    const math = <math><a /></math>;
 
     expect(div.firstChild).toHaveProperty(prop, xhtmlNs);
     expect(svg.firstChild).toHaveProperty(prop, svgNs);
+    expect(math.firstChild).toHaveProperty(prop, mathmlNs);
+  });
+
+  it('should detect MathML namespace from nested MathML parent for `a` tag', () => {
+    const mrow = <math><mrow><a /></mrow></math>;
+
+    expect(mrow.firstChild!.firstChild).toHaveProperty(prop, mathmlNs);
   });
 
   it('should detect namespace from parent tag for `script` tag', () => {
@@ -75,8 +84,10 @@ describe('ns', () => {
   it('should get parent namespace from scope', () => {
     const div = <div>{globalThis && <a />}</div>;
     const svg = <svg>{globalThis && <a />}</svg>;
+    const math = <math>{globalThis && <a />}</math>;
 
     expect(div.firstChild).toHaveProperty(prop, xhtmlNs);
     expect(svg.firstChild).toHaveProperty(prop, svgNs);
+    expect(math.firstChild).toHaveProperty(prop, mathmlNs);
   });
 });

--- a/tests/utils/t.ts
+++ b/tests/utils/t.ts
@@ -30,6 +30,9 @@ export const styleImport = (template: TTemplate): string =>
 export const svgImport = (template: TTemplate): string =>
   `import{svgNs as _svgNs,jsx as _jsx}from"jsx-dom-runtime";/*#__PURE__*/${getSource(template)}`;
 
+export const mathmlImport = (template: TTemplate): string =>
+  `import{mathmlNs as _mathmlNs,jsx as _jsx}from"jsx-dom-runtime";/*#__PURE__*/${getSource(template)}`;
+
 export const attrImport = (template: TTemplate): string =>
   `import{setAttributes as _setAttributes,jsx as _jsx}from"jsx-dom-runtime";/*#__PURE__*/${getSource(template)}`;
 


### PR DESCRIPTION
Introduce MathML support for namespace transformations and utility imports, enabling proper handling of MathML elements in the transformation process. This enhancement includes tests to verify the correct transformation of MathML tags and their namespaces.